### PR TITLE
feat: option for attributes having dotnotation

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1452,7 +1452,7 @@ class QueryGenerator {
           ? this.quoteAttribute(attr, options.model)
           : this.escape(attr);
       }
-      if (!_.isEmpty(options.include) && !attr.includes('.') && addTable) {
+      if (!_.isEmpty(options.include) && (!attr.includes('.') || options.dotnotation) && addTable) {
         attr = `${mainTableAs}.${attr}`;
       }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1672,6 +1672,7 @@ class Model {
    * @param  {object}                                                    [options.having] Having options
    * @param  {string}                                                    [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
    * @param  {boolean|Error}                                             [options.rejectOnEmpty=false] Throws an error when no records found
+   * @param  {boolean}                                                   [options.dotnotation] Allows including tables having the same attribute/column names - which have a dot in them. 
    *
    * @see
    * {@link Sequelize#query}


### PR DESCRIPTION
The select query raises ambiguity errors when I join two tables that have the same attribute/column names which contain a dot(".") in them.

This PR fixes it by provides a new option;
options.dotnotation = true